### PR TITLE
Get rid of tchek

### DIFF
--- a/build_links_test.go
+++ b/build_links_test.go
@@ -3,10 +3,12 @@ package jsonapi
 import (
 	"testing"
 
-	"github.com/mfcochauxlaberge/tchek"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestBuildSelfLink(t *testing.T) {
+	assert := assert.New(t)
+
 	tests := []struct {
 		name           string
 		res            Resource
@@ -34,6 +36,6 @@ func TestBuildSelfLink(t *testing.T) {
 		res.SetID(test.id)
 
 		link := buildSelfLink(res, "http://example.com")
-		tchek.AreEqual(t, test.name, test.expectedString, link)
+		assert.Equal(test.expectedString, link, test.name)
 	}
 }

--- a/document_test.go
+++ b/document_test.go
@@ -4,12 +4,13 @@ import (
 	"testing"
 
 	. "github.com/mfcochauxlaberge/jsonapi"
-	"github.com/mfcochauxlaberge/tchek"
+	"github.com/stretchr/testify/assert"
 )
 
 // TestDocument ...
 func TestDocument(t *testing.T) {
-	pl1 := Document{}
+	assert := assert.New(t)
 
-	tchek.AreEqual(t, "empty", nil, pl1.Data)
+	pl1 := Document{}
+	assert.Equal(nil, pl1.Data, "empty")
 }

--- a/error_test.go
+++ b/error_test.go
@@ -5,10 +5,13 @@ import (
 	"testing"
 
 	. "github.com/mfcochauxlaberge/jsonapi"
-	"github.com/mfcochauxlaberge/tchek"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestError(t *testing.T) {
+	assert := assert.New(t)
+
 	tests := []struct {
 		name           string
 		err            Error
@@ -67,6 +70,6 @@ func TestError(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		tchek.AreEqual(t, test.name, test.err.Error(), test.expectedString)
+		assert.Equal(test.err.Error(), test.expectedString, test.name)
 	}
 }

--- a/filter_query_test.go
+++ b/filter_query_test.go
@@ -7,10 +7,12 @@ import (
 	"testing"
 
 	. "github.com/mfcochauxlaberge/jsonapi"
-	"github.com/mfcochauxlaberge/tchek"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestFilterQuery(t *testing.T) {
+	assert := assert.New(t)
+
 	// time1, _ := time.Parse(time.RFC3339Nano, "2012-05-16T17:45:28.2539Z")
 	// time2, _ := time.Parse(time.RFC3339Nano, "2013-06-24T22:03:34.8276Z")
 
@@ -52,15 +54,15 @@ func TestFilterQuery(t *testing.T) {
 		cdt := Condition{}
 		err := json.Unmarshal([]byte(test.query), &cdt)
 
-		tchek.ErrorExpected(t, test.name, test.expectedError, err)
+		assert.Equal(test.expectedError, err != nil, test.name)
 
 		if !test.expectedError {
-			tchek.AreEqual(t, test.name, test.expectedCondition, cdt)
+			assert.Equal(test.expectedCondition, cdt, test.name)
 
 			data, err := json.Marshal(&cdt)
-			tchek.UnintendedError(err)
+			assert.NoError(err, test.name)
 
-			tchek.AreEqual(t, test.name, tchek.MakeOneLineNoSpaces(test.query), tchek.MakeOneLineNoSpaces(string(data)))
+			assert.Equal(makeOneLineNoSpaces(test.query), makeOneLineNoSpaces(string(data)), test.name)
 		}
 	}
 
@@ -69,13 +71,13 @@ func TestFilterQuery(t *testing.T) {
 		Op:  "=",
 		Val: func() {},
 	})
-	tchek.ErrorExpected(t, "function as value", true, err)
+	assert.Equal(true, err != nil, "function as value")
 
 	_, err = json.Marshal(&Condition{
 		Op:  "",
 		Val: "",
 	})
-	tchek.ErrorExpected(t, "empty operation and value", false, err) // TODO
+	assert.Equal(false, err != nil, "empty operation and value") // TODO
 }
 
 func BenchmarkMarshalFilterQuery(b *testing.B) {

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.11
 
 require (
 	github.com/google/uuid v1.1.1
-	github.com/mfcochauxlaberge/tchek v0.3.0
 	github.com/mitchellh/copystructure v1.0.0
 	github.com/stretchr/testify v1.3.0
 )

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,6 @@ github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/mfcochauxlaberge/tchek v0.3.0 h1:SFmqbnfjxMbP7yV/FuHioIwYI9tmDtmO9Jd5smGu0KQ=
-github.com/mfcochauxlaberge/tchek v0.3.0/go.mod h1:e8jX6VID1Ku1XAZq8lkxRuGfSKIFL9sL7w4E3WDkx7o=
 github.com/mitchellh/copystructure v1.0.0 h1:Laisrj+bAB6b/yJwB5Bt3ITZhGJdqmxquMKeZ+mmkFQ=
 github.com/mitchellh/copystructure v1.0.0/go.mod h1:SNtv71yrdKgLRyLFxmLdkAbkKEFWgYaq1OVrnRcwhnw=
 github.com/mitchellh/reflectwalk v1.0.0 h1:9D+8oIskB4VJBN5SFlmc27fSlIBZaov1Wpk/IfikLNY=

--- a/marshaling_test.go
+++ b/marshaling_test.go
@@ -11,10 +11,13 @@ import (
 	"time"
 
 	. "github.com/mfcochauxlaberge/jsonapi"
-	"github.com/mfcochauxlaberge/tchek"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestMarshalResource(t *testing.T) {
+	assert := assert.New(t)
+
 	loc, _ := time.LoadLocation("")
 	schema := newMockSchema()
 
@@ -65,13 +68,13 @@ func TestMarshalResource(t *testing.T) {
 		rawurl := fmt.Sprintf("%s/%s/%s%s", test.prepath, resType, id, test.params)
 
 		url, err := ParseRawURL(schema, rawurl)
-		tchek.UnintendedError(err)
+		assert.NoError(err, test.name)
 
 		doc.Meta = test.meta
 
 		// Marshal
 		payload, err := Marshal(doc, url)
-		tchek.ErrorExpected(t, test.name, test.errorExpected, err)
+		assert.Equal(test.errorExpected, err != nil, test.name)
 
 		if !test.errorExpected {
 			var out bytes.Buffer
@@ -82,18 +85,20 @@ func TestMarshalResource(t *testing.T) {
 
 			// Retrieve the expected result from file
 			content, err := ioutil.ReadFile("testdata/" + test.payloadFile + ".json")
-			tchek.UnintendedError(err)
+			assert.NoError(err, test.name)
 			out.Reset()
 			json.Indent(&out, content, "", "\t")
 			// Trim because otherwise there is an extra line at the end
 			expectedOutput := strings.TrimSpace(out.String())
 
-			tchek.AreEqual(t, test.name, expectedOutput, output)
+			assert.Equal(expectedOutput, output, test.name)
 		}
 	}
 }
 
 func TestMarshalCollection(t *testing.T) {
+	assert := assert.New(t)
+
 	loc, _ := time.LoadLocation("")
 	schema := newMockSchema()
 
@@ -144,13 +149,13 @@ func TestMarshalCollection(t *testing.T) {
 		rawurl := fmt.Sprintf("%s/%s%s", test.prepath, resType, test.params)
 
 		url, err := ParseRawURL(schema, rawurl)
-		tchek.UnintendedError(err)
+		assert.NoError(err, test.name)
 
 		doc.Meta = test.meta
 
 		// Marshal
 		payload, err := Marshal(doc, url)
-		tchek.ErrorExpected(t, test.name, test.errorExpected, err)
+		assert.Equal(test.errorExpected, err != nil, test.name)
 
 		if !test.errorExpected {
 			var out bytes.Buffer
@@ -161,18 +166,20 @@ func TestMarshalCollection(t *testing.T) {
 
 			// Retrieve the expected result from file
 			content, err := ioutil.ReadFile("testdata/" + test.payloadFile + ".json")
-			tchek.UnintendedError(err)
+			assert.NoError(err, test.name)
 			out.Reset()
 			json.Indent(&out, content, "", "\t")
 			// Trim because otherwise there is an extra line at the end
 			expectedOutput := strings.TrimSpace(out.String())
 
-			tchek.AreEqual(t, test.name, expectedOutput, output)
+			assert.Equal(expectedOutput, output, test.name)
 		}
 	}
 }
 
 func TestMarshalErrors(t *testing.T) {
+	assert := assert.New(t)
+
 	// Reset the IDs because the tests can't predict them.
 	resetIDs := func(errors []Error) []Error {
 		for i := range errors {
@@ -222,7 +229,7 @@ func TestMarshalErrors(t *testing.T) {
 		doc.Data = test.errors
 		// Marshal
 		payload, err := Marshal(doc, nil)
-		tchek.ErrorExpected(t, test.name, test.errorExpected, err)
+		assert.Equal(test.errorExpected, err != nil, test.name)
 
 		if !test.errorExpected {
 			var out bytes.Buffer
@@ -233,13 +240,13 @@ func TestMarshalErrors(t *testing.T) {
 
 			// Retrieve the expected result from file
 			content, err := ioutil.ReadFile("testdata/" + test.payloadFile + ".json")
-			tchek.UnintendedError(err)
+			assert.NoError(err, test.name)
 			out.Reset()
 			json.Indent(&out, content, "", "\t")
 			// Trim because otherwise there is an extra line at the end
 			expectedOutput := strings.TrimSpace(out.String())
 
-			tchek.AreEqual(t, test.name, expectedOutput, output)
+			assert.Equal(expectedOutput, output, test.name)
 		}
 	}
 }

--- a/request_test.go
+++ b/request_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestNewRequest(t *testing.T) {
+	assert := assert.New(t)
+
 	// Schema
 	schema := newMockSchema()
 
@@ -35,8 +37,7 @@ func TestNewRequest(t *testing.T) {
 		req := httptest.NewRequest(test.method, test.url, body)
 
 		doc, err := NewRequest(req, test.schema)
-		assert.Equal(t, test.expectedError, err)
-
-		assert.Equal(t, test.method, doc.Method)
+		assert.Equal(test.expectedError, err, test.name)
+		assert.Equal(test.method, doc.Method, test.name)
 	}
 }

--- a/resource_test.go
+++ b/resource_test.go
@@ -5,10 +5,13 @@ import (
 	"time"
 
 	. "github.com/mfcochauxlaberge/jsonapi"
-	"github.com/mfcochauxlaberge/tchek"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestEqual(t *testing.T) {
+	assert := assert.New(t)
+
 	now := time.Now()
 
 	mt11 := Wrap(&mockType1{
@@ -97,9 +100,9 @@ func TestEqual(t *testing.T) {
 		ToManyFromMany: []string{"a", "b", "c"},
 	})
 
-	tchek.AreEqual(t, "compare same resource with itself", true, Equal(mt11, mt11))
-	tchek.AreEqual(t, "compare two identical resources", true, Equal(mt11, mt12))
-	tchek.AreEqual(t, "compare two identical resources (different IDs)", false, EqualStrict(mt11, mt12))
-	tchek.AreEqual(t, "compare two different resources", false, Equal(mt11, mt13))
-	tchek.AreEqual(t, "compare resources of different types", false, Equal(mt11, mt21))
+	assert.Equal(true, Equal(mt11, mt11), "compare same resource with itself")
+	assert.Equal(true, Equal(mt11, mt12), "compare two identical resources")
+	assert.Equal(false, EqualStrict(mt11, mt12), "compare two identical resources (different IDs)")
+	assert.Equal(false, Equal(mt11, mt13), "compare two different resources")
+	assert.Equal(false, Equal(mt11, mt21), "compare resources of different types")
 }

--- a/simple_url_test.go
+++ b/simple_url_test.go
@@ -5,10 +5,13 @@ import (
 	"testing"
 
 	. "github.com/mfcochauxlaberge/jsonapi"
-	"github.com/mfcochauxlaberge/tchek"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestSimpleURL(t *testing.T) {
+	assert := assert.New(t)
+
 	tests := []struct {
 		name          string
 		url           string
@@ -216,8 +219,8 @@ func TestSimpleURL(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		u, err := url.Parse(tchek.MakeOneLineNoSpaces(test.url))
-		tchek.UnintendedError(err)
+		u, err := url.Parse(makeOneLineNoSpaces(test.url))
+		assert.NoError(err, test.name)
 
 		url, err := NewSimpleURL(u)
 
@@ -233,7 +236,7 @@ func TestSimpleURL(t *testing.T) {
 			err = jaErr
 		}
 
-		tchek.AreEqual(t, test.name, test.expectedURL, url)
-		tchek.AreEqual(t, test.name, test.expectedError, err)
+		assert.Equal(test.expectedURL, url, test.name)
+		assert.Equal(test.expectedError, err, test.name)
 	}
 }

--- a/simple_url_util_test.go
+++ b/simple_url_util_test.go
@@ -3,10 +3,12 @@ package jsonapi
 import (
 	"testing"
 
-	"github.com/mfcochauxlaberge/tchek"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestParseCommaList(t *testing.T) {
+	assert := assert.New(t)
+
 	tests := []struct {
 		name          string
 		source        string
@@ -58,11 +60,13 @@ func TestParseCommaList(t *testing.T) {
 
 	for _, test := range tests {
 		value := parseCommaList(test.source)
-		tchek.AreEqual(t, test.name, test.expectedValue, value)
+		assert.Equal(test.expectedValue, value, test.name)
 	}
 }
 
 func TestParseFragments(t *testing.T) {
+	assert := assert.New(t)
+
 	tests := []struct {
 		name          string
 		source        string
@@ -105,11 +109,13 @@ func TestParseFragments(t *testing.T) {
 
 	for _, test := range tests {
 		value := parseFragments(test.source)
-		tchek.AreEqual(t, test.name, test.expectedValue, value)
+		assert.Equal(test.expectedValue, value, test.name)
 	}
 }
 
 func TestDeduceRoute(t *testing.T) {
+	assert := assert.New(t)
+
 	tests := []struct {
 		name          string
 		source        []string
@@ -156,6 +162,6 @@ func TestDeduceRoute(t *testing.T) {
 
 	for _, test := range tests {
 		value := deduceRoute(test.source)
-		tchek.AreEqual(t, test.name, test.expectedValue, value)
+		assert.Equal(test.expectedValue, value, test.name)
 	}
 }

--- a/unmarshaling_test.go
+++ b/unmarshaling_test.go
@@ -4,10 +4,13 @@ import (
 	"testing"
 
 	. "github.com/mfcochauxlaberge/jsonapi"
-	"github.com/mfcochauxlaberge/tchek"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestUnmarshalResource(t *testing.T) {
+	assert := assert.New(t)
+
 	schema := newMockSchema()
 
 	res1 := Wrap(&mockType3{
@@ -19,8 +22,7 @@ func TestUnmarshalResource(t *testing.T) {
 	})
 
 	url1, err := ParseRawURL(schema, "/mocktypes3/mt1")
-	tchek.UnintendedError(err)
-
+	assert.NoError(err)
 	meta1 := map[string]interface{}{
 		"str": "a string\\^ç\"",
 		"num": float64(42),
@@ -32,25 +34,24 @@ func TestUnmarshalResource(t *testing.T) {
 	doc1.Meta = meta1
 
 	body1, err := Marshal(doc1, url1)
-	tchek.UnintendedError(err)
-
+	assert.NoError(err)
 	pl1, err := Unmarshal(body1, url1, schema)
-	tchek.UnintendedError(err)
-
+	assert.NoError(err)
 	// dst1 := pl1.Data.(Resource)
 
-	// tchek.HaveEqualAttributes(t, "same attribues", res1, dst1) TODO Fix test
-	tchek.AreEqual(t, "same meta object", meta1, pl1.Meta)
+	// assert.HaveEqualAttributes(t, "same attribues", res1, dst1) TODO Fix test
+	assert.Equal(meta1, pl1.Meta, "same meta object")
 }
 
 func TestUnmarshalIdentifier(t *testing.T) {
+	assert := assert.New(t)
+
 	schema := newMockSchema()
 
 	id1 := Identifier{ID: "abc123", Type: "mocktypes1"}
 
 	url1, err := ParseRawURL(schema, "/mocktypes3/mt1/relationships/rel1")
-	tchek.UnintendedError(err)
-
+	assert.NoError(err)
 	meta1 := map[string]interface{}{
 		"str": "a string\\^ç\"",
 		"num": float64(42),
@@ -62,18 +63,18 @@ func TestUnmarshalIdentifier(t *testing.T) {
 	doc1.Meta = meta1
 
 	body1, err := Marshal(doc1, url1)
-	tchek.UnintendedError(err)
-
+	assert.NoError(err)
 	pl1, err := Unmarshal(body1, url1, schema)
-	tchek.UnintendedError(err)
-
+	assert.NoError(err)
 	dst1 := pl1.Data.(Identifier)
 
-	tchek.AreEqual(t, "same identifier", id1, dst1)
-	tchek.AreEqual(t, "same meta map", meta1, pl1.Meta)
+	assert.Equal(id1, dst1, "same identifier")
+	assert.Equal(meta1, pl1.Meta, "same meta map")
 }
 
 func TestUnmarshalIdentifiers(t *testing.T) {
+	assert := assert.New(t)
+
 	schema := newMockSchema()
 
 	ids1 := Identifiers{
@@ -83,7 +84,7 @@ func TestUnmarshalIdentifiers(t *testing.T) {
 	}
 
 	url1, err := ParseRawURL(schema, "/mocktypes3/mt1/relationships/rel2")
-	tchek.UnintendedError(err)
+	assert.NoError(err)
 
 	meta1 := map[string]interface{}{
 		"str": "a string\\^ç\"",
@@ -96,13 +97,13 @@ func TestUnmarshalIdentifiers(t *testing.T) {
 	doc1.Meta = meta1
 
 	body1, err := Marshal(doc1, url1)
-	tchek.UnintendedError(err)
+	assert.NoError(err)
 
 	pl1, err := Unmarshal(body1, url1, schema)
-	tchek.UnintendedError(err)
+	assert.NoError(err)
 
 	dst1 := pl1.Data.(Identifiers)
 
-	tchek.AreEqual(t, "same identifiers", ids1, dst1)
-	tchek.AreEqual(t, "same meta map", meta1, pl1.Meta)
+	assert.Equal(ids1, dst1, "same identifiers")
+	assert.Equal(meta1, pl1.Meta, "same meta map")
 }

--- a/url_test.go
+++ b/url_test.go
@@ -5,10 +5,13 @@ import (
 	"testing"
 
 	. "github.com/mfcochauxlaberge/jsonapi"
-	"github.com/mfcochauxlaberge/tchek"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestParseURL(t *testing.T) {
+	assert := assert.New(t)
+
 	// Schema
 	schema := newMockSchema()
 
@@ -175,20 +178,22 @@ func TestParseURL(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		u, _ := url.Parse(tchek.MakeOneLineNoSpaces(test.url))
+		u, _ := url.Parse(makeOneLineNoSpaces(test.url))
 		url, err := ParseRawURL(schema, u.String())
-		tchek.ErrorExpected(t, test.name, test.expectedError, err)
+		assert.Equal(test.expectedError, err != nil, test.name)
 
-		// test.expectedURL.Path = tchek.MakeOneLineNoSpaces(test.expectedURL.Path)
+		// test.expectedURL.Path = makeOneLineNoSpaces(test.expectedURL.Path)
 
 		if !test.expectedError {
 			url.Params = nil
-			tchek.AreEqual(t, test.name, test.expectedURL, *url)
+			assert.Equal(test.expectedURL, *url, test.name)
 		}
 	}
 }
 
 func TestParseParams(t *testing.T) {
+	assert := assert.New(t)
+
 	// Schema
 	schema := newMockSchema()
 	mockTypes1, _ := schema.GetType("mocktypes1")
@@ -378,14 +383,14 @@ func TestParseParams(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		u, err := url.Parse(tchek.MakeOneLineNoSpaces(test.url))
-		tchek.UnintendedError(err)
+		u, err := url.Parse(makeOneLineNoSpaces(test.url))
+		assert.NoError(err, test.name)
 
 		su, err := NewSimpleURL(u)
-		tchek.UnintendedError(err)
+		assert.NoError(err, test.name)
 
 		params, err := NewParams(schema, su, test.resType)
-		tchek.ErrorExpected(t, test.name, test.expectedError, err)
+		assert.Equal(test.expectedError, err != nil, test.name)
 
 		// Set Attrs and Rels
 		for resType, fields := range test.expectedParams.Fields {
@@ -407,7 +412,7 @@ func TestParseParams(t *testing.T) {
 			// fmt.Printf("EXPECTED:\n%s\n", data)
 			// data, _ = json.MarshalIndent(params, "", "\t")
 			// fmt.Printf("PROVIDED:\n%s\n", data)
-			tchek.AreEqual(t, test.name, test.expectedParams, *params)
+			assert.Equal(test.expectedParams, *params, test.name)
 		}
 	}
 }

--- a/util_test.go
+++ b/util_test.go
@@ -1,0 +1,23 @@
+package jsonapi_test
+
+import "strings"
+
+func makeOneLine(str string) string {
+	str = strings.TrimSpace(str)
+	str = strings.Replace(str, "\t", " ", -1)
+	str = strings.Replace(str, "\n", " ", -1)
+
+	for {
+		str2 := strings.Replace(str, "  ", " ", -1)
+		if str == str2 {
+			return str
+		}
+		str = str2
+	}
+}
+
+func makeOneLineNoSpaces(str string) string {
+	str = strings.Replace(str, "\t", "", -1)
+	str = strings.Replace(str, "\n", "", -1)
+	return strings.Replace(str, " ", "", -1)
+}

--- a/wrapper_test.go
+++ b/wrapper_test.go
@@ -7,10 +7,13 @@ import (
 	"time"
 
 	. "github.com/mfcochauxlaberge/jsonapi"
-	"github.com/mfcochauxlaberge/tchek"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestWrapper(t *testing.T) {
+	assert := assert.New(t)
+
 	loc, _ := time.LoadLocation("")
 
 	res1 := &mockType1{
@@ -33,8 +36,8 @@ func TestWrapper(t *testing.T) {
 
 	// ID and type
 	id, typ := wrap1.IDAndType()
-	tchek.AreEqual(t, "id", res1.ID, id)
-	tchek.AreEqual(t, "type", "mocktypes1", typ)
+	assert.Equal(res1.ID, id, "id")
+	assert.Equal("mocktypes1", typ, "type")
 
 	// Get attributes
 	v1 := reflect.ValueOf(res1).Elem()
@@ -44,15 +47,15 @@ func TestWrapper(t *testing.T) {
 		n := sf.Tag.Get("json")
 
 		if sf.Tag.Get("api") == "attr" {
-			tchek.AreEqual(t, "api tag", f.Interface(), wrap1.Get(n))
+			assert.Equal(f.Interface(), wrap1.Get(n), "api tag")
 		}
 	}
 
 	// Set attributes
 	wrap1.Set("str", "another_string")
-	tchek.AreEqual(t, "set string attribute", "another_string", wrap1.Get("str"))
+	assert.Equal("another_string", wrap1.Get("str"), "set string attribute")
 	wrap1.Set("int", 3)
-	tchek.AreEqual(t, "set int attribute", 3, wrap1.Get("int"))
+	assert.Equal(3, wrap1.Get("int"), "set int attribute")
 
 	aStr := "another_string_ptr"
 	aInt := int(123)
@@ -88,8 +91,8 @@ func TestWrapper(t *testing.T) {
 
 	// ID and type
 	id, typ = wrap2.IDAndType()
-	tchek.AreEqual(t, "id 2", res2.ID, id)
-	tchek.AreEqual(t, "type 2", "mocktypes2", typ)
+	assert.Equal(res2.ID, id, "id 2")
+	assert.Equal("mocktypes2", typ, "type 2")
 
 	// Get attributes
 	v2 := reflect.ValueOf(res2).Elem()
@@ -99,36 +102,36 @@ func TestWrapper(t *testing.T) {
 		n := sf.Tag.Get("json")
 
 		if sf.Tag.Get("api") == "attr" {
-			tchek.AreEqual(t, "api tag 2", f.Interface(), wrap2.Get(n))
+			assert.Equal(f.Interface(), wrap2.Get(n), "api tag 2")
 		}
 	}
 
 	// Set attributes
 	var anotherString = "anotherString"
 	wrap2.Set("strptr", &anotherString)
-	tchek.AreEqual(t, "set string pointer attribute", &anotherString, wrap2.Get("strptr"))
+	assert.Equal(&anotherString, wrap2.Get("strptr"), "set string pointer attribute")
 	var newInt = 3
 	wrap2.Set("intptr", &newInt)
-	tchek.AreEqual(t, "set int pointer attribute", &newInt, wrap2.Get("intptr"))
+	assert.Equal(&newInt, wrap2.Get("intptr"), "set int pointer attribute")
 	wrap2.Set("uintptr", nil)
 	if wrap2.Get("uintptr") != nil {
 		// We first do a != nil check because that's what we are really
 		// checking and reflect.DeepEqual doesn't work exactly work the same
 		// way. If the nil check fails, then the next line will fail too.
-		tchek.AreEqual(t, "nil pointer", nil, wrap2.Get("uintptr"))
+		assert.Equal(t, "nil pointer", nil, wrap2.Get("uintptr"))
 	}
 	if res2.UintPtr != nil {
 		// We first do a != nil check because that's what we are really
 		// checking and reflect.DeepEqual doesn't work exactly work the same
 		// way. If the nil check fails, then the next line will fail too.
-		tchek.AreEqual(t, "nil pointer 2", nil, res2.UintPtr)
+		assert.Equal(t, "nil pointer 2", nil, res2.UintPtr)
 	}
 
 	// Copy
 	wrap3 := wrap1.Copy()
 
 	for _, attr := range wrap1.Attrs() {
-		tchek.AreEqual(t, "copied attribute", wrap1.Get(attr.Name), wrap3.Get(attr.Name))
+		assert.Equal(wrap1.Get(attr.Name), wrap3.Get(attr.Name), "copied attribute")
 
 		if attr.Type == AttrTypeBool && !attr.Null {
 			wrap3.Set(attr.Name, !wrap1.Get(attr.Name).(bool))
@@ -139,6 +142,6 @@ func TestWrapper(t *testing.T) {
 		} else {
 			wrap3.Set(attr.Name, "0")
 		}
-		tchek.AreNotEqual(t, fmt.Sprintf("modified copied attribute %s (%v)", attr.Name, attr.Type), wrap1.Get(attr.Name), wrap3.Get(attr.Name))
+		assert.NotEqual(wrap1.Get(attr.Name), wrap3.Get(attr.Name), fmt.Sprintf("modified copied attribute %s (%v)", attr.Name, attr.Type))
 	}
 }


### PR DESCRIPTION
Let's get rid of this homemade library and use `stretchr/testify` instead.