### PR TITLE
Make Type return a zero instance

### DIFF
--- a/helpers.go
+++ b/helpers.go
@@ -164,6 +164,12 @@ func Reflect(v interface{}) (Type, error) {
 		}
 	}
 
+	// NewFunc
+	res := Wrap(reflect.New(val.Type()).Interface())
+	typ.NewFunc = func() Resource {
+		return res.Copy()
+	}
+
 	return typ, nil
 }
 

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -14,4 +14,14 @@ func TestReflect(t *testing.T) {
 	assert.Panics(func() {
 		MustReflect("invalid")
 	})
+
+	mock := mockType1{
+		ID:    "abc13",
+		Str:   "string",
+		Int:   -42,
+		Uint8: 12,
+	}
+	typ, err := Reflect(mock)
+	assert.NoError(err)
+	assert.Equal(true, Equal(Wrap(&mockType1{}), typ.New()))
 }

--- a/type.go
+++ b/type.go
@@ -31,6 +31,8 @@ type Type struct {
 	Name  string
 	Attrs map[string]Attr
 	Rels  map[string]Rel
+
+	zero Resource
 }
 
 // AddAttr adds an attributes to the type.
@@ -114,6 +116,11 @@ func (t *Type) Fields() []string {
 	}
 	sort.Strings(fields)
 	return fields
+}
+
+// Instance ...
+func (t *Type) Instance() Resource {
+	return t.zero.Copy()
 }
 
 // Attr represents a resource attribute.

--- a/type_test.go
+++ b/type_test.go
@@ -57,7 +57,7 @@ func TestType(t *testing.T) {
 	assert.Error(err)
 }
 
-func TestNewFunc(t *testing.T) {
+func TestTypeNewFunc(t *testing.T) {
 	assert := assert.New(t)
 
 	// NewFunc is nil

--- a/type_test.go
+++ b/type_test.go
@@ -57,6 +57,24 @@ func TestType(t *testing.T) {
 	assert.Error(err)
 }
 
+func TestNewFunc(t *testing.T) {
+	assert := assert.New(t)
+
+	// NewFunc is nil
+	typ := &Type{}
+	assert.Equal(&SoftResource{Type: typ}, typ.New())
+
+	// NewFunc is not nil
+	typ = &Type{
+		NewFunc: func() Resource {
+			res := &SoftResource{}
+			res.SetID("abc123")
+			return res
+		},
+	}
+	assert.Equal("abc123", typ.New().GetID())
+}
+
 func TestInverseRel(t *testing.T) {
 	assert := assert.New(t)
 


### PR DESCRIPTION
Make Type return a zero instance, which could be very useful in a better version of Unmarshal where the payload is unmarshaled into a proper instance of the type instead of a SoftResource.