### PR TITLE
Add Go 1.13 to .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: go
 go:
   - 1.11.x
   - 1.12.x
+  - 1.13.x
 
 branches:
   only:


### PR DESCRIPTION
The current build of golangci-lint offered from GitHub does not work with Go 1.13. I need to wait for a new binary built with Go 1.13.

I will wait a little before merging the PR. If it takes too much time I can go back to building golangci-lint myself in the CI pipeline.