### PR TITLE
Fix NewRequest so it doesn't ignore query params

### DIFF
--- a/request.go
+++ b/request.go
@@ -15,7 +15,12 @@ func NewRequest(r *http.Request, schema *Schema) (*Request, error) {
 		return nil, err
 	}
 
-	url, err := NewURLFromRaw(schema, r.URL.EscapedPath())
+	su, err := NewSimpleURL(r.URL)
+	if err != nil {
+		return nil, err
+	}
+
+	url, err := NewURL(schema, su)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Fixes #113.

I didn't add a test because query params are well tested in simple_url.go, and your test setup for request.go doesn't lend itself to testing whether query params make it through or not.